### PR TITLE
Move data in 64K blocks when migrating persistent disks

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1132,7 +1132,7 @@ func (p linux) MigratePersistentDisk(fromMountPoint, toMountPoint string) (err e
 
 	// Golang does not implement a file copy that would allow us to preserve dates...
 	// So we have to shell out to tar to perform the copy instead of delegating to the FileSystem
-	tarCopy := fmt.Sprintf("(tar -C %s -cf - .) | (tar -C %s -xpf -)", fromMountPoint, toMountPoint)
+	tarCopy := fmt.Sprintf("(tar -C %s -b 128 -cf - .) | (tar -C %s -b 128 -xpf -)", fromMountPoint, toMountPoint)
 	_, _, _, err = p.cmdRunner.RunCommand("sh", "-c", tarCopy)
 	if err != nil {
 		err = bosherr.WrapError(err, "Copying files from old disk to new disk")


### PR DESCRIPTION
instead of using the default (10K)

See #107